### PR TITLE
Responsive activities fix

### DIFF
--- a/app/assets/stylesheets/partials/activities/_show.sass
+++ b/app/assets/stylesheets/partials/activities/_show.sass
@@ -16,7 +16,7 @@ $types: participant ok remove, owner edit edit
           @extend %icon-button-#{nth($type, 3)}
 
   section
-    width: percentage(1/3)
+    width: 349px
     float: left
     position: relative
 


### PR DESCRIPTION
The sessions/activities index was not responsive with the width calculated using SASS. Setting it to a fixed width makes it responsive (again).

Ernesto Miguez and I sat down to figure this out at Railscamp Germany!
