### PR TITLE
Run on domain rubyweek.org

### DIFF
--- a/Cloudfile
+++ b/Cloudfile
@@ -15,8 +15,7 @@ eurucamp-activities-production:
   environment: production # RAILS_ENV
   domains:
     - eurucamp-activities-production.shellyapp.com
-    - rubyweek.eurucamp.org
-    - activities.eurucamp.org
+    - rubyweek.org
   servers:
     app1:
       size: small


### PR DESCRIPTION
We will use rubyweek.org as our domain. We no longer need the two subdomains, they should redirect from now on.