### PR TITLE
Fix for broken twitter avatar urls

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
   end
 
   def twitter_avatar_url(handle)
-    "https://twitter.com/api/users/profile_image/#{handle}"
+    "https://twitter.com/#{handle}/profile_image?size=normal"
   end
 
   def avatar_url(user, size = 64)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#avatar_url' do
+    subject { avatar_url(user, size) }
+    let(:size) { 64 }
+
+    context 'with a Twitter account' do
+      let(:user) { User.new(twitter_handle: 'eurucamp') }
+      it { is_expected.to match %r{//twitter.com/#{user.twitter_handle}/profile_image} }
+    end
+
+    context 'without a Twitter account' do
+      let(:user) { User.new }
+      it { is_expected.to match %r{//gravatar.com/avatar/\w+.png\?s=#{size}} }
+    end
+  end
+end


### PR DESCRIPTION
Twitter avatar URLs are currently broken. This pull request fixes the issue.