### PR TITLE
Disable the anytime option for activities

### DIFF
--- a/app/views/activities/_form.html.haml
+++ b/app/views/activities/_form.html.haml
@@ -9,13 +9,6 @@
   %span.divider> &ndash;
   - fancy_datime_select f, :end_time, @activity
 
-  %fieldset.anytime
-    %span.between
-      = t("common.or").downcase
-    %label.inline
-      = f.check_box :anytime
-      = t("activity_form.anytime.hint")
-
   %hr
 
   %label.location>

--- a/db/migrate/20150724211941_change_anytime_default.rb
+++ b/db/migrate/20150724211941_change_anytime_default.rb
@@ -1,0 +1,9 @@
+class ChangeAnytimeDefault < ActiveRecord::Migration
+  def up
+    change_column_default :activities, :anytime, false
+  end
+
+  def down
+    change_column_default :activities, :anytime, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,22 +11,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150628112434) do
+ActiveRecord::Schema.define(version: 20150724211941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "activities", force: true do |t|
-    t.string   "name",                  default: "",   null: false
+    t.string   "name",                     default: "",    null: false
     t.text     "description"
     t.string   "location"
     t.datetime "start_time"
-    t.integer  "limit_of_participants", default: 10
+    t.integer  "limit_of_participants",    default: 10
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "creator_id"
-    t.integer  "participations_count",  default: 0,    null: false
-    t.boolean  "anytime",               default: true, null: false
+    t.integer  "participations_count",     default: 0,     null: false
+    t.boolean  "anytime",                  default: false, null: false
     t.text     "requirements"
     t.datetime "end_time"
     t.text     "image_url"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -210,9 +210,9 @@ RSpec.describe Activity do
     it { is_expected.to     accept_values_for(:location, "football pitch" ) }
     it { is_expected.not_to accept_values_for(:location, "", nil) }
 
-    it { is_expected.to     accept_values_for(:start_time, Time.now, nil) }
+    it { is_expected.to     accept_values_for(:start_time, Time.now) }
 
-    it { is_expected.to     accept_values_for(:end_time, Time.now, nil) }
+    it { is_expected.to     accept_values_for(:end_time, Time.now) }
 
     it { is_expected.to     accept_values_for(:limit_of_participants, nil, 12, 100) }
     it { is_expected.not_to accept_values_for(:limit_of_participants, -1, 0) }


### PR DESCRIPTION
Now that the app was extended to the time around eurucamp, the anytime
option does not make sense anymore (it used to mean anytime during
eurucamp).

Next step is removing the feature completely.