### PR TITLE
Add form to delete an activity

### DIFF
--- a/app/assets/stylesheets/partials/activities/_form.sass
+++ b/app/assets/stylesheets/partials/activities/_form.sass
@@ -89,3 +89,10 @@ form#new-activity
     display: none
     width: 80%
     padding: 3em 0
+
+.delete-activity
+  margin-top: 4em
+  header
+    margin-bottom: 0.5em
+  button
+    background-color: $red

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -40,8 +40,12 @@ class ActivitiesController < ApiController
   end
 
   def destroy
-    @activity.destroy if @activity
-    respond_with(@activity, location: activities_path)
+    if @activity && params[:confirm_delete] && @activity.destroy
+      redirect_to root_path, notice: I18n.t("destroy_activity.notice")
+    else
+      flash[:error] = I18n.t("destroy_activity.error")
+      render :edit
+    end
   end
 
   private

--- a/app/views/activities/_delete_form.html.haml
+++ b/app/views/activities/_delete_form.html.haml
@@ -1,0 +1,8 @@
+= form_tag activity_path(@activity), method: :delete do
+
+  %fieldset
+    %label.inline
+      = check_box_tag :confirm_delete
+      = t("delete_activity_form.confirmation", count: @activity.participants.count)
+
+  = button_tag t("delete_activity_form.submit")

--- a/app/views/activities/edit.html.haml
+++ b/app/views/activities/edit.html.haml
@@ -10,3 +10,12 @@
       = link_to t("activities.new.label").downcase, new_activity_path
 
   = render "form"
+
+
+%article.delete-activity
+  %header
+    %h2= t("activities.danger_zone")
+    %p.meta
+      %strong= t("delete_activity_form.title")
+
+  = render "delete_form"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,7 @@ en:
       image_url:
         invalid: "not valid URL"
         not_supported_protocol: "protocol not supported ;)"
+    danger_zone: Danger Zone
 
   new_activity:
     title: Organize an activity
@@ -107,6 +108,10 @@ en:
     title: Edit your activity
     notice: Your activity has been updated!
     error: Your changes could not be saved. Please check your input.
+
+  destroy_activity:
+    notice: Your activity has been deleted!
+    error: Your activity could not be deleted. Did you check the confirmation?
 
   activity_form:
     markdown_hint: You can use Markdown here
@@ -131,6 +136,15 @@ en:
     image_url:
       label: URL for an image
       hint: Upload an image to e.g. imgur.com and link it here
+
+  delete_activity_form:
+    title:
+      Delete activity
+    confirmation:
+      one: Really delete this activity (with currently one participant)
+      other: Really delete this activity (with currently %{count} participants)
+    submit:
+      Delete activity
 
   footer_nav:
     about:

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe ActivitiesController do
   end
 
   describe "#destroy" do
-    subject { delete :destroy, {id: activity_id} }
+    subject { delete :destroy, {id: activity_id, confirm_delete: true} }
 
     before do
       sign_in(current_user)
@@ -164,7 +164,7 @@ RSpec.describe ActivitiesController do
       expect(activity).to receive(:destroy).and_return(true)
     end
 
-    it { is_expected.to redirect_to activities_path }
+    it { is_expected.to redirect_to root_path }
 
   end
 

--- a/spec/features/activites_spec.rb
+++ b/spec/features/activites_spec.rb
@@ -52,4 +52,41 @@ RSpec.describe "Activities", :type => :feature do
       expect(page).to have_xpath('//li[@title="Anonymous"]')
     end
   end
+
+  context 'deleting an activity' do
+    it 'deletes activity when checkbox is checked' do
+      login_as(creator)
+      visit "/activities/#{activity.id}"
+      click_link 'Edit'
+      check 'Really delete this activity (with currently 2 participants)'
+      click_button 'Delete activity'
+
+      get_redirected_to_homepage
+      activity_is_deleted
+    end
+
+    it 'does not delete activity when checkbox is not checked' do
+      login_as(creator)
+      visit "/activities/#{activity.id}"
+      click_link 'Edit'
+
+      click_button 'Delete activity'
+
+      activity_is_not_deleted
+    end
+  end
+
+  def activity_is_not_deleted
+    expect(page).to have_content('Your activity could not be deleted.')
+    expect(Activity.exists?(activity.id)).to be_truthy
+  end
+
+  def get_redirected_to_homepage
+    expect(current_path).to eq(root_path)
+  end
+
+  def activity_is_deleted
+    expect(page).to have_content('Your activity has been deleted!')
+    expect(Activity.exists?(activity.id)).to be_falsy
+  end
 end


### PR DESCRIPTION
Previously it wasn't possible to delete your own activities, which bit
me once when I created a test activity by accident on the production
system instead of locally.

This adds a danger zone area at the bottom of the edit form, with a
checkbox that needs to be checked to confirm the deletion.