### PR TITLE
Remove margin from form

### DIFF
--- a/app/assets/stylesheets/partials/activities/_form.sass
+++ b/app/assets/stylesheets/partials/activities/_form.sass
@@ -1,5 +1,4 @@
 form#new-activity
-  margin: 0 150px
 
   input.date-capture,
   input.time-capture


### PR DESCRIPTION
This makes the form a bit more usable on narrow devices. Previously, the
fields were squashed horizontally to unreadable once the width got below
~ 600px.