### PR TITLE
Responsify views & allow Neat's visual-grid to be used

### DIFF
--- a/app/assets/stylesheets/_settings.sass
+++ b/app/assets/stylesheets/_settings.sass
@@ -2,6 +2,9 @@
 
 // DEV
 $visual-grid:          false
+$visual-grid-opacity:  0.2
+$visual-grid-index:    front
+$visual-grid-color:    blue
 
 // grid set-up
 $column:               225px

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,6 +1,6 @@
 @import "normalize";
-@import "settings";
 @import "bourbon";
+@import "settings";
 @import "neat";
 @import "utils";
 @import "base";

--- a/app/assets/stylesheets/partials/_user.sass
+++ b/app/assets/stylesheets/partials/_user.sass
@@ -32,7 +32,7 @@ body.user
     font-size: 1.5em
 
   section.form
-    width: 640px
+    +span-columns(6)
     padding: 70px
     margin: 0 auto
     background: $white

--- a/app/assets/stylesheets/partials/_user.sass
+++ b/app/assets/stylesheets/partials/_user.sass
@@ -33,7 +33,9 @@ body.user
 
   section.form
     +span-columns(6)
-    padding: 70px
+    padding: 10px
+    +media($smartphone-landscape)
+      padding: 70px
     margin: 0 auto
     background: $white
     box-shadow: 0 0 7px transparentize($black, 0.9)

--- a/app/assets/stylesheets/partials/activities/_form.sass
+++ b/app/assets/stylesheets/partials/activities/_form.sass
@@ -54,15 +54,19 @@ form#new-activity
   label
     &.location
       display: inline-block
-      width: 80%
+      +span-columns(6)
+      +media($tablet-lite)
+        +span-columns(3)
 
     &.limit-of-participants
       display: inline-block
       text-align: right
-      width: 20%
+      +span-columns(6)
 
-      input
-        width: 85%
+      +media($tablet-lite)
+        +span-columns(1)
+        input
+          width: 85%
 
     &.image-url
       .preview

--- a/app/assets/stylesheets/partials/activities/_index.sass
+++ b/app/assets/stylesheets/partials/activities/_index.sass
@@ -216,15 +216,6 @@ a#new-activity
         +transition(all 0.15s ease-out 0.15s)
 
 
-  +media($smartphone-portrait)
-    li
-      +span-columns(2)
-
-
   +media($tablet-lite)
-    li
-      +span-columns(2)
-
-  +media($tablet-portrait-plus)
     li
       +span-columns(2)


### PR DESCRIPTION
These changes were planned in the "pair with me" activity with @til during eurucamp 2015. This PR, basically:

- Responsify Users form (login/register/password recovery)
- Improve Activities form (create/edit) usability in small screens
- Fix import order, so Neat's visual-grid can be used in development mode (it also includes some default styling for the visual grid)
- Get rid of unneeded code.

I think that after merging this PR, both #71 and #90 could be closed.

Please notice that further work on date pickers is still pending (https://github.com/eurucamp/eurucamp-activities/issues/54), specially with small devices) ;)