### PR TITLE
Add client-side validation to the 'limit_of_participants' numerical input

### DIFF
--- a/app/views/activities/_form.html.haml
+++ b/app/views/activities/_form.html.haml
@@ -18,7 +18,7 @@
       %a#show-map= t("activity_form.location.show-map")
 
   %label.limit-of-participants>
-    = f.number_field :limit_of_participants, placeholder: "5"
+    = f.number_field :limit_of_participants, placeholder: 5, min: 1
     %small
       = t("activity_form.limit_of_participants.hint")
 

--- a/app/views/activities/_form.html.haml
+++ b/app/views/activities/_form.html.haml
@@ -18,7 +18,7 @@
       %a#show-map= t("activity_form.location.show-map")
 
   %label.limit-of-participants>
-    = f.number_field :limit_of_participants, placeholder: 5, min: 1
+    = f.number_field :limit_of_participants, placeholder: 10, min: 1
     %small
       = t("activity_form.limit_of_participants.hint")
 


### PR DESCRIPTION
- Question: Since `limit_of_participants` have a default value of 10, it seems like the input's placeholder of 5 is not being used at all. Should we get rid of it?
- We can close #167 after this PR is merged ;)