### PR TITLE
Show 3 activities per row over tablet-portrait-plus size

### DIFF
--- a/app/assets/stylesheets/partials/activities/_index.sass
+++ b/app/assets/stylesheets/partials/activities/_index.sass
@@ -219,3 +219,7 @@ a#new-activity
   +media($tablet-lite)
     li
       +span-columns(2)
+
+  +media($tablet-portrait-plus)
+    li
+      +span-columns(2)


### PR DESCRIPTION
The relevant media query was wrongly deleted by commit 8c9aa1827fa2172fc02afc74e169b2fc5d16ab45.
This made that just 2 activities per row were being displayed over tablet-portrait-plus size.